### PR TITLE
feature/Add expireAt field for Firestore Persistence

### DIFF
--- a/src/FirebaseFunctionsRateLimiter.ts
+++ b/src/FirebaseFunctionsRateLimiter.ts
@@ -22,8 +22,10 @@ export class FirebaseFunctionsRateLimiter {
     public static withFirestoreBackend(
         configuration: FirebaseFunctionsRateLimiterConfiguration,
         firestore: admin.firestore.Firestore | FirestoreEquivalent,
+        createExpireAtFromMillis?: ((millis: number) => any)
     ): FirebaseFunctionsRateLimiter {
         const provider = new FirestorePersistenceProvider(firestore);
+        if (createExpireAtFromMillis) provider.setCreateExpireAtFromMillis(createExpireAtFromMillis);
         return new FirebaseFunctionsRateLimiter(configuration, provider);
     }
 
@@ -60,6 +62,7 @@ export class FirebaseFunctionsRateLimiter {
     private constructor(
         configuration: FirebaseFunctionsRateLimiterConfiguration,
         persistenceProvider: PersistenceProvider,
+        createExpireAtFromMillis?: (millis: number) => any,
     ) {
         this.configurationFull = {
             ...FirebaseFunctionsRateLimiterConfiguration.DEFAULT_CONFIGURATION,

--- a/src/GenericRateLimiter.ts
+++ b/src/GenericRateLimiter.ts
@@ -72,6 +72,7 @@ export class GenericRateLimiter {
 
         const newRecord: PersistenceRecord = {
             u: recentUsages,
+            expireAt: timestampsSeconds.expireAt
         };
         return newRecord;
     }
@@ -91,11 +92,12 @@ export class GenericRateLimiter {
         return numOfRecentUsages >= this.configuration.maxCalls;
     }
 
-    private getTimestampsSeconds(): { current: number; threshold: number } {
+    private getTimestampsSeconds(): { current: number; threshold: number, expireAt: number } {
         const currentServerTimestampSeconds: number = this.timestampProvider.getTimestampSeconds();
         return {
             current: currentServerTimestampSeconds,
             threshold: currentServerTimestampSeconds - this.configuration.periodSeconds,
+            expireAt: currentServerTimestampSeconds + this.configuration.periodSeconds
         };
     }
 }

--- a/src/persistence/PersistenceProviderMock.ts
+++ b/src/persistence/PersistenceProviderMock.ts
@@ -52,6 +52,7 @@ export class PersistenceProviderMock implements PersistenceProvider {
     private createEmptyRecord(): PersistenceRecord {
         return {
             u: [],
+            expireAt: null
         };
     }
 

--- a/src/persistence/PersistenceRecord.ts
+++ b/src/persistence/PersistenceRecord.ts
@@ -3,6 +3,7 @@ import ow from "ow";
 export interface PersistenceRecord {
     // "u" instead of "usages" to save data transfer
     u: number[];
+    expireAt: number|null;
 }
 
 export namespace PersistenceRecord {

--- a/src/persistence/RealtimeDbPersistenceProvider.ts
+++ b/src/persistence/RealtimeDbPersistenceProvider.ts
@@ -76,6 +76,7 @@ export class RealtimeDbPersistenceProvider implements PersistenceProvider {
     private createEmptyRecord(): PersistenceRecord {
         return {
             u: [],
+            expireAt: null
         };
     }
 }


### PR DESCRIPTION
## Description

We need the ability to automatically remove entries from Firestore that are no longer in use. Currently, the library does not provide a built-in mechanism to set an expireAt field for Firestore entries. This PR adds expireAt field saved in Firestore that is equal to last usage plus configuration threshold. 

Caution: It is stored only in Firestore as RealtimeDb has no support for TTL.

